### PR TITLE
コマンドの履歴が残るよう実装

### DIFF
--- a/RDSRemocon/Models/CLICommands.cs
+++ b/RDSRemocon/Models/CLICommands.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace RDSRemocon.Models {
+    class CLICommands {
+
+        private Process process = new Process() {
+            StartInfo = new ProcessStartInfo() {
+                FileName = System.Environment.GetEnvironmentVariable("ComSpec"),
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = false,
+                CreateNoWindow = true
+            }
+        };
+
+        /// <summary>
+        /// 現状 DBInstance は一台しか使っていないので、返却値は単一の文字列。
+        /// </summary>
+        /// <returns></returns>
+        public string getDBInstanceIdentifier() {
+            process.StartInfo.Arguments = @"/c aws rds describe-db-instances";
+            process.Start();
+
+            string text = process.StandardOutput.ReadToEnd();
+
+            var regex = new Regex("\"DBInstanceIdentifier\": \"(.*)\"", RegexOptions.IgnoreCase);
+            var matches = regex.Matches(text);
+            return matches[0].Groups[1].Value;
+        }
+
+        public string startDBInstance(string instanceName) {
+            string commandText = @"/c aws rds start-db-instance --db-instance-identifier ";
+            process.StartInfo.Arguments = commandText + instanceName;
+            process.Start();
+            return process.StandardOutput.ReadToEnd();
+        }
+
+        public string stopDBInstance(string instanceName) {
+            string commandText = @"/c aws rds stop-db-instance --db-instance-identifier ";
+            process.StartInfo.Arguments = commandText + instanceName;
+            process.Start();
+            return process.StandardOutput.ReadToEnd();
+        }
+
+        public string getDBInstanceStatus() {
+            process.StartInfo.Arguments = @"/c aws rds describe-db-instances";
+            process.Start();
+            return process.StandardOutput.ReadToEnd();
+        }
+
+
+    }
+}

--- a/RDSRemocon/Models/Log.cs
+++ b/RDSRemocon/Models/Log.cs
@@ -8,12 +8,18 @@ using System.Threading.Tasks;
 namespace RDSRemocon.Models {
     public class Log : BindableBase{
 
+        private string executionCommandType;
         private string message;
         private DateTime executionDateTime;
 
-        public Log(string message, DateTime executionDateTime) {
+        public Log(string executionCommandType ,string message, DateTime executionDateTime) {
+            ExecutionCommandType = executionCommandType;
             Message = message;
             ExecutionDateTime = executionDateTime;
+        }
+
+        public string ExecutionCommandType {
+            get => executionCommandType; set => SetProperty(ref executionCommandType, value);
         }
 
         public string Message {
@@ -23,5 +29,6 @@ namespace RDSRemocon.Models {
         public DateTime ExecutionDateTime {
             get => executionDateTime; set => SetProperty(ref executionDateTime, value);
         }
+
     }
 }

--- a/RDSRemocon/Models/Log.cs
+++ b/RDSRemocon/Models/Log.cs
@@ -1,0 +1,27 @@
+﻿using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RDSRemocon.Models {
+    public class Log : BindableBase{
+
+        private string message;
+        private DateTime executionDateTime;
+
+        public Log(string message, DateTime executionDateTime) {
+            Message = message;
+            ExecutionDateTime = executionDateTime;
+        }
+
+        public string Message {
+            get => message; set => SetProperty(ref message, value);
+        }
+
+        public DateTime ExecutionDateTime {
+            get => executionDateTime; set => SetProperty(ref executionDateTime, value);
+        }
+    }
+}

--- a/RDSRemocon/RDSRemocon.csproj
+++ b/RDSRemocon/RDSRemocon.csproj
@@ -64,6 +64,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Models\Log.cs" />
     <Compile Include="ViewModels\HistoryViewModel.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">

--- a/RDSRemocon/RDSRemocon.csproj
+++ b/RDSRemocon/RDSRemocon.csproj
@@ -64,6 +64,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Models\CLICommands.cs" />
     <Compile Include="Models\Log.cs" />
     <Compile Include="ViewModels\HistoryViewModel.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />

--- a/RDSRemocon/RDSRemocon.csproj
+++ b/RDSRemocon/RDSRemocon.csproj
@@ -35,7 +35,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -52,7 +51,6 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
   </ItemGroup>
-
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>
@@ -66,44 +64,38 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ViewModels\HistoryViewModel.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Prism.Unity" Version="7.2.0.1422" />
   </ItemGroup>
-
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/RDSRemocon/ViewModels/HistoryViewModel.cs
+++ b/RDSRemocon/ViewModels/HistoryViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RDSRemocon.ViewModels {
+    public class HistoryViewModel : BindableBase {
+    }
+}

--- a/RDSRemocon/ViewModels/HistoryViewModel.cs
+++ b/RDSRemocon/ViewModels/HistoryViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Mvvm;
+using RDSRemocon.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,5 +8,14 @@ using System.Threading.Tasks;
 
 namespace RDSRemocon.ViewModels {
     public class HistoryViewModel : BindableBase {
+
+        private List<Log> logs = new List<Log>();
+
+        public HistoryViewModel() {
+        }
+
+        public List<Log> Logs {
+            get => logs; set => SetProperty(ref logs, value);
+        }
     }
 }

--- a/RDSRemocon/ViewModels/MainWindowViewModel.cs
+++ b/RDSRemocon/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,8 @@
 using Prism.Mvvm;
 using RDSRemocon.Models;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Windows.Threading;
@@ -40,6 +42,12 @@ namespace RDSRemocon.ViewModels
             set => SetProperty(ref lastUpdateDateTime, value);
         }
 
+        private ObservableCollection<Log> logs = new ObservableCollection<Log>();
+        public ObservableCollection<Log> Logs {
+            get => logs;
+            set => SetProperty(ref logs, value);
+        }
+
         private string updateIntervalMinuteString = "";
         public string UpdateIntervalMinuteString {
             get => updateIntervalMinuteString;
@@ -69,6 +77,7 @@ namespace RDSRemocon.ViewModels
                 new DelegateCommand(() => {
                     Output = cliExecuter.getDBInstanceStatus();
                     State = extractDBInstanceState(Output);
+                    Logs.Add(new Log("getStatus" ,State, DateTime.Now));
                     LastUpdateDateTime = DateTime.Now;
                 });
 

--- a/RDSRemocon/ViewModels/MainWindowViewModel.cs
+++ b/RDSRemocon/ViewModels/MainWindowViewModel.cs
@@ -12,17 +12,6 @@ namespace RDSRemocon.ViewModels
 {
     public class MainWindowViewModel : BindableBase
     {
-
-        private Process process = new Process() {
-            StartInfo = new ProcessStartInfo() {
-                FileName = System.Environment.GetEnvironmentVariable("ComSpec"),
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardInput = false,
-                CreateNoWindow = true
-            }
-        };
-
         private string _title = "Prism Application";
         public string Title
         {

--- a/RDSRemocon/ViewModels/MainWindowViewModel.cs
+++ b/RDSRemocon/ViewModels/MainWindowViewModel.cs
@@ -55,19 +55,18 @@ namespace RDSRemocon.ViewModels
             StartDBInstanceCommand = 
                 new DelegateCommand(() => {
                     cliExecuter.startDBInstance(cliExecuter.getDBInstanceIdentifier());
+                    updateDBInstanceStatus("start");
                 });
 
             StopDBInstanceCommand =
                 new DelegateCommand(() => {
                     cliExecuter.stopDBInstance(cliExecuter.getDBInstanceIdentifier());
+                    updateDBInstanceStatus("stop");
                 });
 
             UpdateDBInstanceStatusCommand =
                 new DelegateCommand(() => {
-                    Output = cliExecuter.getDBInstanceStatus();
-                    State = extractDBInstanceState(Output);
-                    Logs.Add(new Log("getStatus" ,State, DateTime.Now));
-                    LastUpdateDateTime = DateTime.Now;
+                    updateDBInstanceStatus("getStatus");
                 });
 
             int updateInterval = 20;
@@ -95,6 +94,13 @@ namespace RDSRemocon.ViewModels
         private string extractDBInstanceState(string text) {
             var regex = new Regex("\"DBInstanceStatus\": \"(.*)\"", RegexOptions.IgnoreCase);
             return regex.Matches(text)[0].Groups[1].Value;
+        }
+
+        private void updateDBInstanceStatus(string commandType) {
+            Output = cliExecuter.getDBInstanceStatus();
+            State = extractDBInstanceState(Output);
+            Logs.Insert(0, new Log(commandType, State, DateTime.Now));
+            LastUpdateDateTime = DateTime.Now;
         }
     }
 }

--- a/RDSRemocon/Views/MainWindow.xaml
+++ b/RDSRemocon/Views/MainWindow.xaml
@@ -138,8 +138,45 @@
                    Grid.Column="0"
                    />
 
-        <ListView Grid.Row="2">
-            
+        <ListView DataContext="{StaticResource HistoryViewModel}"
+                  ItemsSource="{Binding Logs}"
+                  Grid.Row="2">
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+
+            <ListView.ItemTemplate>
+                <DataTemplate>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ExecutionDateTime}"
+                               />
+
+                    <Border Grid.Column="1"
+                            Background="Black"
+                            Width="2"
+                            Margin="5,0"
+                            />
+
+                    <TextBlock Grid.Column="2"
+                           Text="{Binding Message}"
+                           />
+
+                    </Grid>
+
+                </DataTemplate>
+            </ListView.ItemTemplate>
+
         </ListView>
 
         <StatusBar Grid.Row="3"

--- a/RDSRemocon/Views/MainWindow.xaml
+++ b/RDSRemocon/Views/MainWindow.xaml
@@ -10,9 +10,12 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance vms:MainWindowViewModel, IsDesignTimeCreatable=True}"
 
-        Title="{Binding Title}" Height="250" Width="400">
+        Title="{Binding Title}" Height="400" Width="400">
 
     <Window.Resources>
+
+        <vms:HistoryViewModel x:Key="HistoryViewModel" />
+
         <Style TargetType="Button"
                x:Key="buttonStyle"
                >
@@ -60,6 +63,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition/>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -134,7 +138,11 @@
                    Grid.Column="0"
                    />
 
-        <StatusBar Grid.Row="2"
+        <ListView Grid.Row="2">
+            
+        </ListView>
+
+        <StatusBar Grid.Row="3"
                    >
             <TextBlock Text="Status"/>
 

--- a/RDSRemocon/Views/MainWindow.xaml
+++ b/RDSRemocon/Views/MainWindow.xaml
@@ -138,8 +138,7 @@
                    Grid.Column="0"
                    />
 
-        <ListView DataContext="{StaticResource HistoryViewModel}"
-                  ItemsSource="{Binding Logs}"
+        <ListView ItemsSource="{Binding Logs}"
                   Grid.Row="2">
 
             <ListView.ItemContainerStyle>
@@ -155,7 +154,9 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition/>
+                            <ColumnDefinition Width="70"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition />
                         </Grid.ColumnDefinitions>
 
                     <TextBlock Grid.Column="0"
@@ -169,6 +170,16 @@
                             />
 
                     <TextBlock Grid.Column="2"
+                               Text="{Binding ExecutionCommandType}"
+                               />
+
+                    <Border Grid.Column="3"
+                            Background="Black"
+                            Width="2"
+                            Margin="5,0"
+                            />
+
+                    <TextBlock Grid.Column="4"
                            Text="{Binding Message}"
                            />
 


### PR DESCRIPTION
- クラス追加 / 履歴表示部分を管理するビューモデルをプロジェクトとXAMLに追加
- UI変更 / ListView の見た目を修正
- 移動 / CLIコマンドの実行部分を新しいクラスに分離
- ビューモデルを一つに戻す
- 削除 / 不要になったフィールドを削除
- 機能追加 / 起動、停止ボタンを押した際にも履歴が残るよう実装

close #5
